### PR TITLE
ci: add `date` command to pull-request-commenter

### DIFF
--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -10,7 +10,15 @@ on:
       - labeled
       - opened
 jobs:
+  date:
+    # by having this job before add-comment, `add-comment` can be debugged
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log the current date
+        run: date
+
   add-comment:
+    needs: date
     if: >
       (github.event.pull_request.label == 'ok-to-test' &&
       github.event.pull_request.merged != true) ||

--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -12,120 +12,18 @@ on:
 jobs:
   add-comment:
     needs: date
-    if: >
-      (github.event.pull_request.label == 'ok-to-test' &&
-      github.event.pull_request.merged != true) ||
-      (github.event.pull_request.action == 'opened' &&
-      contains(github.event.pull_request.labels.*.name,'ok-to-test'))
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
       - name: Add comment to trigger external storage tests for Kubernetes 1.24
+        if: >
+          (github.event.pull_request.label == 'ok-to-test' &&
+          github.event.pull_request.merged != true) ||
+          (github.event.pull_request.action == 'opened' &&
+          contains(github.event.pull_request.labels.*.name,'ok-to-test'))
         uses: peter-evans/create-or-update-comment@v3
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             /test ci/centos/k8s-e2e-external-storage/1.24
-
-      - name: Add comment to trigger external storage tests for Kubernetes 1.25
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/k8s-e2e-external-storage/1.25
-
-      - name: Add comment to trigger external storage tests for Kubernetes 1.26
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/k8s-e2e-external-storage/1.26
-
-      - name: Add comment to trigger external storage tests for Kubernetes 1.27
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/k8s-e2e-external-storage/1.27
-
-      - name: Add comment to trigger helm E2E tests for Kubernetes 1.24
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e-helm/k8s-1.24
-
-      - name: Add comment to trigger helm E2E tests for Kubernetes 1.25
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e-helm/k8s-1.25
-
-      - name: Add comment to trigger helm E2E tests for Kubernetes 1.26
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e-helm/k8s-1.26
-
-      - name: Add comment to trigger helm E2E tests for Kubernetes 1.27
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e-helm/k8s-1.27
-
-      - name: Add comment to trigger E2E tests for Kubernetes 1.24
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e/k8s-1.24
-
-      - name: Add comment to trigger E2E tests for Kubernetes 1.25
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e/k8s-1.25
-
-      - name: Add comment to trigger E2E tests for Kubernetes 1.26
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e/k8s-1.26
-
-      - name: Add comment to trigger E2E tests for Kubernetes 1.27
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/mini-e2e/k8s-1.27
-
-      - name: Add comment to trigger cephfs upgrade tests
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/upgrade-tests-cephfs
-
-      - name: Add comment to trigger rbd upgrade tests
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test ci/centos/upgrade-tests-rbd
-
-      - name: remove ok-to-test-label after commenting
-        uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.issues.removeLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: ["ok-to-test"]
-            })

--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -20,11 +20,7 @@ jobs:
         run: date
 
       - name: Add comment to trigger external storage tests for Kubernetes 1.24
-        if: >
-          (github.event.pull_request.label == 'ok-to-test' &&
-          github.event.pull_request.merged != true) ||
-          (github.event.pull_request.action == 'opened' &&
-          contains(github.event.pull_request.labels.*.name,'ok-to-test'))
+        if: (github.event.pull_request.label == 'ok-to-test' && github.event.pull_request.merged != true) || (github.event.pull_request.action == 'opened' && contains(github.event.pull_request.labels.*.name,'ok-to-test'))
         uses: peter-evans/create-or-update-comment@v3
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -16,6 +16,9 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: date
+        run: date
+
       - name: Add comment to trigger external storage tests for Kubernetes 1.24
         if: >
           (github.event.pull_request.label == 'ok-to-test' &&

--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -10,13 +10,6 @@ on:
       - labeled
       - opened
 jobs:
-  date:
-    # by having this job before add-comment, `add-comment` can be debugged
-    runs-on: ubuntu-latest
-    steps:
-      - name: Log the current date
-        run: date
-
   add-comment:
     needs: date
     if: >

--- a/.github/workflows/pull-request-commentor.yaml
+++ b/.github/workflows/pull-request-commentor.yaml
@@ -19,10 +19,18 @@ jobs:
       - name: date
         run: date
 
-      - name: Add comment to trigger external storage tests for Kubernetes 1.24
-        if: (github.event.pull_request.label == 'ok-to-test' && github.event.pull_request.merged != true) || (github.event.pull_request.action == 'opened' && contains(github.event.pull_request.labels.*.name,'ok-to-test'))
+      - name: Add comment to trigger external storage tests for Kubernetes 1.24 - 1
+        if: (github.event.pull_request.label == 'ok-to-test' && github.event.pull_request.merged != true)
         uses: peter-evans/create-or-update-comment@v3
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            /test ci/centos/k8s-e2e-external-storage/1.24
+            /test ci/centos/k8s-e2e-external-storage/1.24/1
+
+      - name: Add comment to trigger external storage tests for Kubernetes 1.24 - 2
+        if: (github.event.pull_request.action == 'opened' && contains(github.event.pull_request.labels.*.name,'ok-to-test'))
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            /test ci/centos/k8s-e2e-external-storage/1.24/2


### PR DESCRIPTION
By having a job before `add-comment`, GutHub can run the job with debugging enabled, which now shows why the job gets skipped.

